### PR TITLE
Internationalize site name and email in footer

### DIFF
--- a/skin.json
+++ b/skin.json
@@ -18,8 +18,8 @@
 				"responsive": true,
 				"templateDirectory": "skins/WMAU/templates",
 				"messages": [
-					"wmau-talk-link",
-					"wmau-subject-link"
+					"site-email",
+					"sitetitle"
 				]
 			} ]
 		}

--- a/templates/skin.mustache
+++ b/templates/skin.mustache
@@ -63,8 +63,8 @@
 		<section class="skin-wmau-footer-left">
 			<p class="skin-wmau-image-logo-black-small"></p>
 			<p class="skin-wmau-contact">
-				<strong>Wikimedia Australia, Inc.</strong><br>
-				<a href="mailto:contact@wikimedia.org.au">contact@wikimedia.org.au</a>
+				<strong>{{msg-sitetitle}}</strong><br>
+				<a href="mailto:{{msg-site-email}}">{{msg-site-email}}</a>
 			</p>
 		</section>
 		<section class="skin-wmau-footer-right">


### PR DESCRIPTION
Use messages for these strings. A new message "MediaWiki:site-email
is used for the email address.

Note: the previous keys were not working as they were not being
outputted in a template.