### PR TITLE
Remove deprecation warnings in 1.37

### DIFF
--- a/skin.json
+++ b/skin.json
@@ -11,7 +11,7 @@
 	"license-name": "GPL-3.0+",
 	"type": "skin",
 	"requires": {
-		"MediaWiki": ">= 1.35.0"
+		"MediaWiki": ">= 1.37.0"
 	},
 	"ValidSkinNames": {
 		"wmau": {
@@ -19,7 +19,7 @@
 			"args": [ {
 				"name": "WMAU",
 				"responsive": true,
-				"templateDirectory": "skins/WMAU/templates",
+				"templateDirectory": "templates",
 				"styles": [
 					"skins.wmau",
 					"skins.wmau.images"


### PR DESCRIPTION
From 1.37, the template directory should be relative
to the skin not core and will begin omitting deprecation warnings.

Note this change will break compatibility with 1.36 so please
exercise caution when deploying this :)

If you need to maintain compatibility with 1.36, you can set this
inside SkinWMAU constructor safely.

See T262067 for more information